### PR TITLE
Fix indentation in Makefile run-log-int recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,9 +171,9 @@ run-debug: $(ISO_FILE)
 	qemu-system-x86_64 -cdrom $< $(QEMU_FLAGS) -S -s
 
 run-log-int: $(ISO_FILE)
-       qemu-system-x86_64 -cdrom $< $(QEMU_FLAGS) -m 128M -display curses -vga std \
-       -d int,guest_errors,cpu_reset -D qemu.log -debugcon file:qemu.log -serial file:qemu.log \
-       -M smm=off -no-reboot -S -s
+	qemu-system-x86_64 -cdrom $< $(QEMU_FLAGS) -m 128M -display curses -vga std \
+	-d int,guest_errors,cpu_reset -D qemu.log -debugcon file:qemu.log -serial file:qemu.log \
+	-M smm=off -no-reboot -S -s
 
 clean:
 	rm -rf $(BUILD_DIR)


### PR DESCRIPTION
## Summary
- correct indentation for `run-log-int` recipe in Makefile so make no longer reports "multiple target patterns"

## Testing
- `make -n`

------
https://chatgpt.com/codex/tasks/task_e_685e0337d8b48327ad1d10926e1ed502