### PR TITLE
Add host utility installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,8 +510,10 @@ filesystem to run inside the container. A minimal example is shown below:
 }
 ```
 
-The Linux base image is **not** built automatically. If you need a minimal
-Alpine root filesystem for containers, run the helper manually:
+The Linux base image is **not** built automatically. The helper below
+downloads a minimal Alpine rootfs and installs Bash with common GNU
+utilities so your containers have a full set of familiar Linux commands.
+Run it manually:
 
 ```bash
 sudo scripts/build_rootfs.sh /var/images
@@ -519,6 +521,16 @@ sudo scripts/build_rootfs.sh /var/images
 
 This will place `alpine-rootfs.img` under `/var/images`, which you can then
 reference in the `base_image` field of your container configuration.
+
+To install the same set of utilities on the host anonymOS instance, run:
+
+```bash
+sudo scripts/install_host_utils.sh
+```
+
+This uses the available package manager (`apk`, `apt`, or `pacman`) to install
+standard tools like `coreutils` so the host environment has the full suite of
+Linux commands available.
 
 
 ### System Configuration and Proxy Setup

--- a/scripts/build_rootfs.sh
+++ b/scripts/build_rootfs.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Build a minimal Alpine root filesystem image for anonymOS containers
+# Build an Alpine root filesystem image for anonymOS containers
+# with a standard set of Linux utilities preinstalled.
 # Usage: sudo ./scripts/build_rootfs.sh [output_dir]
 
 set -e
@@ -7,6 +8,7 @@ set -e
 OUTPUT_DIR=${1:-/var/images}
 IMAGE="${OUTPUT_DIR}/alpine-rootfs.img"
 SIZE=512M
+PACKAGES="bash bash-completion coreutils util-linux findutils grep sed gawk"
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -24,8 +26,12 @@ ROOTFS_TAR="/tmp/alpine-minirootfs.tar.gz"
 curl -L https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/x86_64/alpine-minirootfs-3.19.1-x86_64.tar.gz -o "$ROOTFS_TAR"
 tar -xzf "$ROOTFS_TAR" -C "$MNT"
 
+# Install a fuller set of commands inside the chroot
+cp /etc/resolv.conf "$MNT/etc/resolv.conf"
+chroot "$MNT" /bin/sh -c "apk add --no-cache $PACKAGES"
+
 umount "$MNT"
 rm -rf "$MNT" "$ROOTFS_TAR"
 
-echo "Base image created at $IMAGE"
+echo "Base image with standard utilities created at $IMAGE"
 

--- a/scripts/install_host_utils.sh
+++ b/scripts/install_host_utils.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Install standard Linux utilities on the anonymOS host.
+# This complements build_rootfs.sh which prepares container images.
+
+set -e
+
+PACKAGES="bash bash-completion coreutils util-linux findutils grep sed gawk"
+
+if command -v apk >/dev/null 2>&1; then
+    echo "Installing packages via apk..."
+    sudo apk add --no-cache $PACKAGES
+elif command -v apt-get >/dev/null 2>&1; then
+    echo "Installing packages via apt-get..."
+    sudo apt-get update
+    sudo apt-get install -y $PACKAGES
+elif command -v pacman >/dev/null 2>&1; then
+    echo "Installing packages via pacman..."
+    sudo pacman -Sy --noconfirm $PACKAGES
+else
+    echo "No supported package manager found. Please install:\n$PACKAGES"
+    exit 1
+fi
+
+echo "Host utilities installed."


### PR DESCRIPTION
## Summary
- install common GNU tools on the anonymOS host with a new helper script
- document how to use the script in the README

## Testing
- `make` *(fails: ldc2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0b42b8448327991e1a85e884584b