### PR TITLE
Add dmd bootstrap script and integrate with build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,9 @@ SH_SOURCES = src/user/apps/sh/interpreter.d \
              src/user/apps/sh/dlexer.d \
              src/user/apps/sh/dparser.d
 SH_BIN = $(BUILD_DIR)/bin/sh
+# Original D compiler built with the cross-compiler
+DMD_DIR = third_party/dmd
+DMD_BIN = $(BUILD_DIR)/bin/dmd
 
 
 
@@ -108,7 +111,7 @@ ALL_KERNEL_D_OBJS              = $(ALL_KERNEL_D_OBJS_NO_GENERATED) $(ANSI_ART_D_
 ALL_ASM_OBJS      = $(patsubst %.s,$(OBJ_DIR)/%.o,$(ALL_ASM_SOURCES))
 ALL_OBJS          = $(ALL_ASM_OBJS) $(ALL_KERNEL_D_OBJS)
 
-.PHONY: all build clean run iso kernel_bin sh
+.PHONY: all build clean run iso kernel_bin sh dmd
 
 
 all: $(ISO_FILE)
@@ -118,11 +121,12 @@ iso: $(ISO_FILE)
 build: $(ISO_FILE)
 
 
-$(ISO_FILE): $(KERNEL_BIN) $(SH_BIN)
+$(ISO_FILE): $(KERNEL_BIN) $(SH_BIN) $(DMD_BIN)
 	@echo ">>> Creating ISO Image..."
 	mkdir -p $(ISO_BOOT_DIR) $(ISO_GRUB_DIR) $(ISO_BIN_DIR)
-	cp $(KERNEL_BIN) $(ISO_BOOT_DIR)/
-	cp $(SH_BIN) $(ISO_BIN_DIR)/
+       cp $(KERNEL_BIN) $(ISO_BOOT_DIR)/
+       cp $(SH_BIN) $(ISO_BIN_DIR)/
+       cp $(DMD_BIN) $(ISO_BIN_DIR)/
 		# Critical: Ensure the backslash '\' after 'then' on the line below
 		# is the *absolute last character* on that line. No trailing spaces.
 		# This is the most common cause for the "expecting fi" error on "line 2".
@@ -166,8 +170,13 @@ $(OBJ_DIR)/%.o: %.d
 
 # Generic rule for Assembly files (preserves source path under OBJ_DIR)
 $(OBJ_DIR)/%.o: %.s
-	        @mkdir -p $(dir $@)
-	        $(AS) $(ASFLAGS) $< -o $@
+                @mkdir -p $(dir $@)
+                $(AS) $(ASFLAGS) $< -o $@
+
+$(DMD_BIN): | $(BUILD_DIR)
+	./scripts/build_dmd.sh
+
+dmd: $(DMD_BIN)
 
 $(SH_BIN): $(SH_SOURCES) | $(BUILD_DIR)
 	        mkdir -p $(dir $@)

--- a/README.md
+++ b/README.md
@@ -558,6 +558,16 @@ When the compiler already embeds the target triple you may need to clear the
 ```bash
 make DC=/path/to/ldc2 DFLAGS_TARGET_64="" build
 ```
+### Bootstrapping the Original D Compiler
+
+To run the stock `dmd` compiler inside anonymOS you need to build it using the cross compiled `ldc2`:
+
+```bash
+./scripts/build_dmd.sh
+```
+
+The resulting binary is placed at `build/bin/dmd` and will be included in the ISO during `make build` so it can be invoked from the anonymOS shell.
+
 
 
 ### System Configuration and Proxy Setup

--- a/scripts/build_dmd.sh
+++ b/scripts/build_dmd.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Build the DMD compiler for anonymOS using the cross-compiler.
+# This expects the dmd sources under third_party/dmd.
+# The resulting binary is copied to build/bin/dmd so it is included
+# in the anonymOS ISO image.
+
+set -e
+
+SCRIPT_DIR="$(dirname "$0")"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DMD_DIR="$PROJECT_ROOT/third_party/dmd"
+BIN_DIR="$PROJECT_ROOT/build/bin"
+HOST_DMD=${HOST_DMD:-ldmd2}
+JOBS=${JOBS:-$(nproc)}
+
+mkdir -p "$BIN_DIR"
+
+make -C "$DMD_DIR" -f Makefile -j$JOBS HOST_DMD="$HOST_DMD" ENABLE_RELEASE=1
+cp "$DMD_DIR/generated/linux/release/64/dmd" "$BIN_DIR/dmd"
+
+echo "DMD built and copied to $BIN_DIR/dmd"


### PR DESCRIPTION
## Summary
- add `scripts/build_dmd.sh` for compiling dmd using the cross compiler
- integrate dmd into the ISO via new Makefile rules
- document how to bootstrap the original D compiler

## Testing
- `make --version`

------
https://chatgpt.com/codex/tasks/task_e_685e41189ecc832793860b093a4fad34