### PR TITLE
Add object-oriented namespace skeleton

### DIFF
--- a/kernel/core/init_stubs.d
+++ b/kernel/core/init_stubs.d
@@ -12,7 +12,11 @@ extern(C) void init_frame_allocator(void* multiboot_info_ptr) {}
 extern(C) void init_paging() {}
 extern(C) void init_kernel_heap() {}
 extern(C) void init_device_manager(void* multiboot_info_ptr) {}
-extern(C) void init_namespace_manager(void* multiboot_info_ptr) {}
+extern(C) void init_namespace_manager(void* multiboot_info_ptr)
+{
+    import kernel.object_namespace : object_namespace_init;
+    object_namespace_init();
+}
 extern(C) void init_capability_supervisor() {}
 extern(C) void init_keyboard_driver()
 {

--- a/kernel/object_namespace.d
+++ b/kernel/object_namespace.d
@@ -1,0 +1,175 @@
+module kernel.object_namespace;
+
+pragma(LDC_no_moduleinfo);
+
+import kernel.lib.stdc.stdlib : malloc, realloc, free;
+import kernel.types : strlen, memcpy, memcmp;
+
+public:
+
+struct ObjMethod {
+    const(char)* name;
+    extern(C) long function(Object*, void**, size_t) func;
+}
+
+struct ObjProperty {
+    const(char)* name;
+    long value;
+}
+
+struct Object {
+    const(char)* name;
+    Object* parent;
+    Object* child;
+    Object* sibling;
+    ObjMethod* methods;
+    size_t methodCount;
+    size_t methodCapacity;
+    ObjProperty* properties;
+    size_t propCount;
+    size_t propCapacity;
+}
+
+__gshared Object* rootObject;
+
+private bool str_eq(const(char)* a, const(char)* b)
+{
+    if(a is null || b is null) return false;
+    auto la = strlen(a);
+    auto lb = strlen(b);
+    if(la != lb) return false;
+    return memcmp(a, b, la) == 0;
+}
+
+extern(C) Object* obj_create(const(char)* name)
+{
+    auto obj = cast(Object*)malloc(Object.sizeof);
+    if(obj is null) return null;
+    obj.name = name;
+    obj.parent = null;
+    obj.child = null;
+    obj.sibling = null;
+    obj.methods = null;
+    obj.methodCount = 0;
+    obj.methodCapacity = 0;
+    obj.properties = null;
+    obj.propCount = 0;
+    obj.propCapacity = 0;
+    return obj;
+}
+
+extern(C) void obj_add_child(Object* parent, Object* child)
+{
+    if(parent is null || child is null) return;
+    child.parent = parent;
+    child.sibling = parent.child;
+    parent.child = child;
+}
+
+extern(C) int obj_add_method(Object* obj, const(char)* name, extern(C) long function(Object*, void**, size_t) func)
+{
+    if(obj is null) return -1;
+    if(obj.methodCount == obj.methodCapacity)
+    {
+        size_t newCap = obj.methodCapacity ? obj.methodCapacity * 2 : 4;
+        auto newMem = cast(ObjMethod*)realloc(obj.methods, newCap * ObjMethod.sizeof);
+        if(newMem is null) return -1;
+        obj.methods = newMem;
+        obj.methodCapacity = newCap;
+    }
+    obj.methods[obj.methodCount].name = name;
+    obj.methods[obj.methodCount].func = func;
+    obj.methodCount++;
+    return 0;
+}
+
+extern(C) int obj_set_property(Object* obj, const(char)* name, long value)
+{
+    if(obj is null) return -1;
+    foreach(i; 0 .. obj.propCount)
+    {
+        if(str_eq(obj.properties[i].name, name))
+        {
+            obj.properties[i].value = value;
+            return 0;
+        }
+    }
+    if(obj.propCount == obj.propCapacity)
+    {
+        size_t newCap = obj.propCapacity ? obj.propCapacity * 2 : 4;
+        auto newMem = cast(ObjProperty*)realloc(obj.properties, newCap * ObjProperty.sizeof);
+        if(newMem is null) return -1;
+        obj.properties = newMem;
+        obj.propCapacity = newCap;
+    }
+    obj.properties[obj.propCount].name = name;
+    obj.properties[obj.propCount].value = value;
+    obj.propCount++;
+    return 0;
+}
+
+private Object* find_child(Object* parent, const(char)* name)
+{
+    auto c = parent.child;
+    while(c !is null)
+    {
+        if(str_eq(c.name, name))
+            return c;
+        c = c.sibling;
+    }
+    return null;
+}
+
+extern(C) Object* obj_lookup(const(char)* path)
+{
+    if(path is null || path[0] != '/') return null;
+    auto cur = rootObject;
+    size_t i = 1;
+    char[64] nameBuf;
+    while(cur !is null && path[i] != 0)
+    {
+        size_t j = 0;
+        while(path[i] != '/' && path[i] != 0 && j < nameBuf.length-1)
+            nameBuf[j++] = path[i++];
+        nameBuf[j] = 0;
+        if(j == 0)
+        {
+            if(path[i] == '/') i++;
+            continue;
+        }
+        cur = find_child(cur, nameBuf.ptr);
+        if(cur is null) return null;
+        if(path[i] == '/') i++;
+    }
+    return cur;
+}
+
+extern(C) long obj_call(const(char)* path, const(char)* methodName, void** args, size_t nargs)
+{
+    auto obj = obj_lookup(path);
+    if(obj is null) return -1;
+    foreach(i; 0 .. obj.methodCount)
+    {
+        if(str_eq(obj.methods[i].name, methodName))
+            return obj.methods[i].func(obj, args, nargs);
+    }
+    return -1;
+}
+
+extern(C) void object_namespace_init()
+{
+    rootObject = obj_create("/");
+    auto sys = obj_create("sys");
+    auto net = obj_create("net");
+    auto user = obj_create("user");
+    auto dev = obj_create("dev");
+    auto proc = obj_create("proc");
+    auto srv = obj_create("srv");
+    obj_add_child(rootObject, sys);
+    obj_add_child(rootObject, net);
+    obj_add_child(rootObject, user);
+    obj_add_child(rootObject, dev);
+    obj_add_child(rootObject, proc);
+    obj_add_child(rootObject, srv);
+}
+


### PR DESCRIPTION
## Summary
- implement `kernel/object_namespace.d` as a basic object hierarchy manager
- initialize the namespace in `init_namespace_manager` stub

## Testing
- `make kernel_bin` *(fails: `ldc2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f16e6fd548327bb10528a06cb55b7