### PR TITLE
Fix D build errors in object namespace and networking code

### DIFF
--- a/kernel/net/arp.d
+++ b/kernel/net/arp.d
@@ -69,9 +69,10 @@ extern(C) void arp_send_request(uint targetIp)
     hdr.tha = [0,0,0,0,0,0];
     hdr.tip = swap32(targetIp);
 
-    ubyte[sizeof(EthernetHeader)+sizeof(ArpHeader)] frame;
+    ubyte[EthernetHeader.sizeof + ArpHeader.sizeof] frame;
     auto eth = cast(EthernetHeader*)frame.ptr;
-    eth.dst[] = [0xFF,0xFF,0xFF,0xFF,0xFF,0xFF];
+    ubyte[6] broadcast = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
+    eth.dst[] = broadcast[];
     eth.src[] = localMac;
     eth.eth_type = swap16(ETH_TYPE_ARP);
 

--- a/kernel/net/ip.d
+++ b/kernel/net/ip.d
@@ -36,7 +36,7 @@ extern(C) void ip_init(uint ip)
 // Build and send IPv4 packet
 extern(C) void ip_send(uint dstIp, ubyte proto, const(ubyte)* payload, size_t len)
 {
-    ubyte[sizeof(EthernetHeader) + sizeof(IpHeader) + 1500] buf; // allocate enough
+    ubyte[EthernetHeader.sizeof + IpHeader.sizeof + 1500] buf; // allocate enough
     auto eth = cast(EthernetHeader*)buf.ptr;
 
     const(ubyte)* dstMac = arp_lookup(dstIp);

--- a/kernel/net/udp.d
+++ b/kernel/net/udp.d
@@ -20,7 +20,7 @@ struct UdpHeader
 // Send UDP datagram
 extern(C) void udp_send(uint dstIp, ushort srcPort, ushort dstPort, const(ubyte)* data, size_t len)
 {
-    ubyte[sizeof(UdpHeader) + 1500] buf;
+    ubyte[UdpHeader.sizeof + 1500] buf;
     auto udp = cast(UdpHeader*)buf.ptr;
     udp.src_port = swap16(srcPort);
     udp.dst_port = swap16(dstPort);
@@ -32,7 +32,7 @@ extern(C) void udp_send(uint dstIp, ushort srcPort, ushort dstPort, const(ubyte)
         payload[i] = data[i];
 
     // Pseudo header for checksum
-    ubyte[12 + sizeof(UdpHeader) + 1500] pseudo; // over-alloc
+    ubyte[12 + UdpHeader.sizeof + 1500] pseudo; // over-alloc
     auto p = pseudo.ptr;
     *(cast(uint*)p) = swap32(localIp); p += 4;
     *(cast(uint*)p) = swap32(dstIp);  p += 4;

--- a/kernel/object_namespace.d
+++ b/kernel/object_namespace.d
@@ -10,9 +10,11 @@ import kernel.object_validator : validate_object_graph;
 
 public:
 
+alias ObjMethodFunc = extern(C) long function(Object*, void**, size_t);
+
 struct ObjMethod {
     const(char)* name;
-    extern(C) long function(Object*, void**, size_t) func;
+    ObjMethodFunc func;
 }
 
 struct ObjProperty {
@@ -69,7 +71,7 @@ extern(C) void obj_add_child(Object* parent, Object* child)
     parent.child = child;
 }
 
-extern(C) int obj_add_method(Object* obj, const(char)* name, extern(C) long function(Object*, void**, size_t) func)
+extern(C) int obj_add_method(Object* obj, const(char)* name, ObjMethodFunc func)
 {
     if(obj is null) return -1;
     if(obj.methodCount == obj.methodCapacity)

--- a/kernel/user_manager.d
+++ b/kernel/user_manager.d
@@ -68,8 +68,8 @@ extern(C) long obj_um_get_current_user(Object* obj, void** args, size_t nargs)
 {
     if(nargs >= 1 && args[0] !is null)
     {
-        auto dest = cast(const(char**) )args[0];
-        *dest = get_current_user();
+        auto dest = cast(char**)args[0];
+        *dest = cast(char*)get_current_user();
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- introduce `ObjMethodFunc` alias for function pointer type
- use `.sizeof` property in networking code
- avoid betterC TypeInfo use in ARP handler
- adjust pointer casting in user manager

## Testing
- `apt-get update`
- `apt-get install -y ldc`
- `make` *(fails: third_party/sh build errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f40cfafb48327a472443d2e4de382