### PR TITLE
Update shell fetch behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ ALL_KERNEL_D_OBJS              = $(ALL_KERNEL_D_OBJS_NO_GENERATED) $(ANSI_ART_D_
 ALL_ASM_OBJS      = $(patsubst %.s,$(OBJ_DIR)/%.o,$(ALL_ASM_SOURCES))
 ALL_OBJS          = $(ALL_ASM_OBJS) $(ALL_KERNEL_D_OBJS)
 
-.PHONY: all build clean run iso kernel_bin sh dmd
+.PHONY: all build clean run iso kernel_bin sh dmd fetch_shell
 
 
 all: $(ISO_FILE)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ The resulting ISO image is written to `build/anonymOS.iso`.  Use `make run` to b
 
 ## Shell Integration
 
-The build pulls the TTY shell from the external repository using `scripts/fetch_shell.sh`.  The shell binary is compiled into the image automatically.
+The build pulls the TTY shell from the external repository using `scripts/fetch_shell.sh`.  \
+Because the `fetch_shell` Makefile target is marked as phony, this step runs on every build,
+ensuring the latest shell sources are fetched and compiled into the image automatically.
 
 ## Object Namespace Overview
 


### PR DESCRIPTION
## Summary
- make `fetch_shell` a phony target so the `-sh` repository is pulled every build
- clarify in README that the shell sources are fetched each build

## Testing
- `make build` *(fails: `ldc2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f431e838483279a788d0be985e98d