### PR TITLE
Add basic D utilities

### DIFF
--- a/src/user/apps/utils/lspci.d
+++ b/src/user/apps/utils/lspci.d
@@ -1,0 +1,18 @@
+import std.stdio;
+import std.file;
+import std.path;
+
+void main() {
+    string root = "/sys/bus/pci/devices";
+    if (!exists(root)) {
+        stderr.writeln("lspci: /sys/bus/pci/devices not found");
+        return;
+    }
+    foreach (entry; dirEntries(root, SpanMode.shallow)) {
+        string vendorFile = buildPath(entry.name, "vendor");
+        string deviceFile = buildPath(entry.name, "device");
+        string vendor = exists(vendorFile) ? strip(readText(vendorFile)) : "";
+        string device = exists(deviceFile) ? strip(readText(deviceFile)) : "";
+        writeln(entry.name.baseName, " \t", vendor, " ", device);
+    }
+}

--- a/src/user/apps/utils/man.d
+++ b/src/user/apps/utils/man.d
@@ -1,0 +1,39 @@
+import std.stdio;
+import std.file;
+import std.path;
+import std.getopt;
+import std.zlib;
+
+string[] sections = ["1", "2", "3", "4", "5", "6", "7", "8"]; // default search
+
+string readManFile(string name) {
+    foreach (sec; sections) {
+        auto base = "/usr/share/man/man" ~ sec ~ "/" ~ name ~ "." ~ sec;
+        if (exists(base ~ ".gz")) {
+            auto comp = read(base ~ ".gz");
+            auto decoded = cast(string)uncompress(comp);
+            return decoded;
+        } else if (exists(base)) {
+            return cast(string)readText(base);
+        }
+    }
+    return "";
+}
+
+void main(string[] args) {
+    string section;
+    auto res = getopt(args, "s|section", &section);
+    if (res.helpWanted || res.errors.length || res.rest.length == 0) {
+        writeln("Usage: man [-s section] NAME");
+        return;
+    }
+    string name = res.rest[0];
+    if (section.length) sections = [section];
+
+    auto text = readManFile(name);
+    if (text.length == 0) {
+        stderr.writeln("man: no entry for ", name);
+        return;
+    }
+    writeln(text);
+}

--- a/src/user/apps/utils/mapfile.d
+++ b/src/user/apps/utils/mapfile.d
@@ -1,0 +1,11 @@
+import std.stdio;
+
+void main(string[] args) {
+    string[] lines;
+    foreach (line; stdin.byLine()) {
+        lines ~= line.idup;
+    }
+    foreach (i, l; lines) {
+        writeln(i, ": ", l);
+    }
+}

--- a/src/user/apps/utils/md5sum.d
+++ b/src/user/apps/utils/md5sum.d
@@ -1,0 +1,32 @@
+import std.stdio;
+import std.digest.md;
+import std.file;
+import std.path;
+
+string digestFile(string path) {
+    auto data = read(path);
+    auto ctx = MD5Digest();
+    ctx.put(data);
+    auto hash = ctx.finish();
+    return hash.toHexString();
+}
+
+void main(string[] args) {
+    if (args.length == 1) {
+        auto data = cast(ubyte[])stdin.readAll();
+        auto ctx = MD5Digest();
+        ctx.put(data);
+        auto hash = ctx.finish();
+        writeln(hash.toHexString(), "  -");
+        return;
+    }
+
+    foreach (file; args[1..$]) {
+        try {
+            auto hex = digestFile(file);
+            writeln(hex, "  ", file);
+        } catch (Exception e) {
+            stderr.writeln("md5sum: ", e.msg);
+        }
+    }
+}

--- a/src/user/apps/utils/mkdir.d
+++ b/src/user/apps/utils/mkdir.d
@@ -1,0 +1,36 @@
+import std.stdio;
+import std.file;
+import std.getopt;
+
+void main(string[] args) {
+    bool parents;
+    bool verbose;
+    auto helpInformation = getopt(args,
+        "p|parents", &parents,
+        "v|verbose", &verbose
+    );
+
+    if (helpInformation.helpWanted || helpInformation.errors.length) {
+        writeln("Usage: mkdir [-p] [-v] DIR...");
+        return;
+    }
+
+    auto dirs = helpInformation.rest;
+    if (dirs.length == 0) {
+        stderr.writeln("mkdir: missing operand");
+        return;
+    }
+
+    foreach (d; dirs) {
+        try {
+            if (parents) {
+                mkdirRecurse(d);
+            } else {
+                mkdir(d);
+            }
+            if (verbose) writeln("created directory: ", d);
+        } catch (FileException e) {
+            stderr.writeln("mkdir: cannot create directory '", d, "': ", e.msg);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement common utilities in D
  - `lspci` via `/sys/bus/pci/devices`
  - `man` for reading simple manual pages
  - `mapfile` for storing stdin lines in an array
  - `md5sum` using `std.digest`
  - `mkdir` with optional `-p` and `-v`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f4441ea7c8327876707322702b55d