### PR TITLE
Add build-time check for TTY shell support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ ALL_KERNEL_D_OBJS              = $(ALL_KERNEL_D_OBJS_NO_GENERATED) $(ANSI_ART_D_
 ALL_ASM_OBJS      = $(patsubst %.s,$(OBJ_DIR)/%.o,$(ALL_ASM_SOURCES))
 ALL_OBJS          = $(ALL_ASM_OBJS) $(ALL_KERNEL_D_OBJS)
 
-.PHONY: all build clean run iso kernel_bin sh dmd fetch_shell
+.PHONY: all build clean run iso kernel_bin sh dmd fetch_shell check_shell_support
 
 
 all: $(ISO_FILE)
@@ -181,9 +181,12 @@ $(DMD_BIN): | $(BUILD_DIR)
 
 dmd: $(DMD_BIN)
 
-$(SH_BIN): fetch_shell $(SH_SOURCES) | $(BUILD_DIR)
+$(SH_BIN): check_shell_support fetch_shell $(SH_SOURCES) | $(BUILD_DIR)
 	mkdir -p $(dir $@)
 	$(DC) $(SH_SOURCES) -of=$@
+
+check_shell_support:
+	./scripts/check_shell_support.sh
 
 fetch_shell:
 	./scripts/fetch_shell.sh

--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ The resulting ISO image is written to `build/anonymOS.iso`.  Use `make run` to b
 
 ## Shell Integration
 
-The build pulls the TTY shell from the external repository using `scripts/fetch_shell.sh`.\
-Because the `fetch_shell` Makefile target is marked as phony, this step runs on every build,
-ensuring the latest shell sources are fetched and compiled into the image automatically. The
-shell's prompt now dynamically displays the logged-in user, namespace, current directory and
-CPU privilege level using the format `user@namespace:/path(permission)`.
+The build pulls the TTY shell from the external repository using `scripts/fetch_shell.sh`.
+Before compiling it, `scripts/check_shell_support.sh` verifies that the kernel provides the
+required terminal and keyboard drivers. If these checks fail the build stops and explains what
+is missing. Because the `fetch_shell` Makefile target is marked as phony, this step runs on
+every build, ensuring the latest shell sources are fetched and compiled into the image
+automatically. The shell's prompt now dynamically displays the logged-in user, namespace,
+current directory and CPU privilege level using the format `user@namespace:/path(permission)`.
 
 ## Object Namespace Overview
 

--- a/scripts/check_shell_support.sh
+++ b/scripts/check_shell_support.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Check if the kernel provides TTY support needed for the -sh shell
+set -e
+SCRIPT_DIR="$(dirname "$0")"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+terminal_file="$PROJECT_ROOT/kernel/terminal.d"
+keyboard_file="$PROJECT_ROOT/kernel/keyboard.d"
+
+echo "Checking shell support..."
+
+if [ ! -f "$terminal_file" ]; then
+    echo "TTY support missing: $terminal_file not found" >&2
+    exit 1
+fi
+
+if [ ! -f "$keyboard_file" ]; then
+    echo "Keyboard driver missing: $keyboard_file not found" >&2
+    exit 1
+fi
+
+# Check for required functions
+if ! grep -q "terminal_writestring" "$terminal_file"; then
+    echo "terminal.d does not define terminal_writestring" >&2
+    exit 1
+fi
+
+if ! grep -q "keyboard_getchar" "$keyboard_file"; then
+    echo "keyboard.d does not define keyboard_getchar" >&2
+    exit 1
+fi
+
+echo "Shell support confirmed."
+exit 0


### PR DESCRIPTION
## Summary
- add `check_shell_support.sh` to verify terminal and keyboard driver presence
- integrate the check into the Makefile before compiling the external `-sh` shell
- update README to describe the new verification step

## Testing
- `scripts/check_shell_support.sh`
- `make -n sh`

------
https://chatgpt.com/codex/tasks/task_e_6860c4312b688327949f94d2310f9e64