### PR TITLE
Embed shell source and build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-			# Makefile for Minimal D OS
+					# Makefile for Minimal D OS
 
 		# Tools
 		DC = ldc2           # D Compiler
@@ -127,10 +127,12 @@ build: $(ISO_FILE)
 
 $(ISO_FILE): $(KERNEL_BIN) $(SH_BIN) $(DMD_BIN)
 	@echo ">>> Creating ISO Image..."
-	mkdir -p $(ISO_BOOT_DIR) $(ISO_GRUB_DIR) $(ISO_BIN_DIR)
+	mkdir -p $(ISO_BOOT_DIR) $(ISO_GRUB_DIR) $(ISO_BIN_DIR) $(ISO_DIR)/third_party $(ISO_DIR)/sys/init
 	cp $(KERNEL_BIN) $(ISO_BOOT_DIR)/
 	cp $(SH_BIN) $(ISO_BIN_DIR)/
 	cp $(DMD_BIN) $(ISO_BIN_DIR)/
+	cp -r third_party/sh $(ISO_DIR)/third_party/
+	cp scripts/install_shell_in_os.sh $(ISO_DIR)/sys/init/
 		# Critical: Ensure the backslash '\' after 'then' on the line below
 		# is the *absolute last character* on that line. No trailing spaces.
 		# This is the most common cause for the "expecting fi" error on "line 2".

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ every build, ensuring the latest shell sources are fetched and compiled into the
 automatically. The shell's prompt now dynamically displays the logged-in user, namespace,
 current directory and CPU privilege level using the format `user@namespace:/path(permission)`.
 
+The ISO also packages the shell sources in `/third_party/sh` along with a helper
+script `install_shell_in_os.sh` located in `/sys/init`.  Running this script
+inside anonymOS compiles the shell with the bundled `dmd` compiler and installs
+the result to `/bin/sh`.  This allows the shell to be rebuilt from source during
+system setup if desired.
+
 ## Object Namespace Overview
 
 At boot an object tree is created that exposes kernel services through a single

--- a/scripts/install_shell_in_os.sh
+++ b/scripts/install_shell_in_os.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Build the third-party -sh shell inside anonymOS using the bundled D compiler.
+# This script is expected to run from within the installed system.
+set -e
+
+SRC_DIR="/third_party/sh"
+DMD="/bin/dmd"
+OUT="/bin/sh"
+
+if [ ! -x "$DMD" ]; then
+    echo "dmd compiler not found at $DMD" >&2
+    exit 1
+fi
+
+if [ ! -d "$SRC_DIR" ]; then
+    echo "Shell sources not found at $SRC_DIR" >&2
+    exit 1
+fi
+
+echo "Compiling shell sources..."
+"$DMD" -I"$SRC_DIR" -I"$SRC_DIR/src" "$SRC_DIR"/src/*.d -of="$OUT"
+
+echo "Shell installed to $OUT"


### PR DESCRIPTION
## Summary
- include third-party shell sources and helper install script when generating the ISO
- document how the shell can be rebuilt inside anonymOS during setup

## Testing
- `make -n build`

------
https://chatgpt.com/codex/tasks/task_e_6860cb42bbd48327866488db1365115d