### PR TITLE
Fix missing dmd source handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ make build
 
 The resulting ISO image is written to `build/anonymOS.iso`.  Use `make run` to boot it in QEMU.
 
+To include the stock `dmd` compiler in the image, run `./scripts/build_dmd.sh` before `make build`. The script automatically fetches the upstream sources if they are missing and compiles them with your cross-compiled `ldc2`.
+
 ## Shell Integration
 
 The build pulls the TTY shell from the external repository using

--- a/scripts/build_dmd.sh
+++ b/scripts/build_dmd.sh
@@ -8,10 +8,21 @@ set -e
 
 SCRIPT_DIR="$(dirname "$0")"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 DMD_DIR="$PROJECT_ROOT/third_party/dmd"
 BIN_DIR="$PROJECT_ROOT/build/bin"
 HOST_DMD=${HOST_DMD:-ldmd2}
 JOBS=${JOBS:-$(nproc)}
+
+# Fetch the dmd sources if they are missing
+if [ ! -d "$DMD_DIR/.git" ]; then
+    echo "Fetching dmd sources..."
+    mkdir -p "$PROJECT_ROOT/third_party"
+    git clone --depth 1 https://github.com/dlang/dmd.git "$DMD_DIR"
+else
+    echo "Updating dmd sources..."
+    git -C "$DMD_DIR" pull --ff-only
+fi
 
 mkdir -p "$BIN_DIR"
 


### PR DESCRIPTION
## Summary
- update README with instructions for building the stock compiler
- make `build_dmd.sh` automatically clone/update dmd sources if absent

## Testing
- `./scripts/check_shell_support.sh`
- `./scripts/build_dmd.sh` *(fails: ldmd2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860cef8d4b88327adf5bbd153b53468