### PR TITLE
Add automatic GDB debug script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ ALL_KERNEL_D_OBJS              = $(ALL_KERNEL_D_OBJS_NO_GENERATED) $(ANSI_ART_D_
 ALL_ASM_OBJS      = $(patsubst %.s,$(OBJ_DIR)/%.o,$(ALL_ASM_SOURCES))
 ALL_OBJS          = $(ALL_ASM_OBJS) $(ALL_KERNEL_D_OBJS)
 
-.PHONY: all build clean run iso kernel_bin sh dmd fetch_shell check_shell_support update-run
+.PHONY: all build clean run iso kernel_bin sh dmd fetch_shell check_shell_support update-run debug
 
 
 all: $(ISO_FILE)
@@ -210,6 +210,8 @@ run-log-int: $(ISO_FILE)
 	qemu-system-x86_64 -cdrom $< $(QEMU_FLAGS) -m 128M -display curses -vga std \
 	-d int,guest_errors,cpu_reset -D qemu.log -debugcon file:qemu.log -serial file:qemu.log \
 	-M smm=off -no-reboot -S -s
+debug:
+	./scripts/run_with_gdb.sh
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ make build
 ```
 
 The resulting ISO image is written to `build/anonymOS.iso`.  Use `make run` to boot it in QEMU.
+For debugging, run `make debug` to build the system, launch QEMU in debug mode and automatically attach GDB.
 
 To include the stock `dmd` compiler in the image, run `./scripts/build_dmd.sh` before `make build`. The script automatically fetches the upstream sources if they are missing and compiles them with your cross-compiled `ldc2`.
 

--- a/scripts/run_with_gdb.sh
+++ b/scripts/run_with_gdb.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Build the ISO and launch QEMU with GDB attached automatically.
+set -e
+SCRIPT_DIR="$(dirname "$0")"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Build the system
+make build
+
+# Start QEMU in debug mode
+qemu-system-x86_64 -cdrom build/anonymOS.iso -S -s -m 128M -display curses -vga std &
+QEMU_PID=$!
+
+# Give QEMU time to open the GDB port
+sleep 1
+
+# Launch GDB with kernel symbols and connect
+gdb -ex "file build/kernel.bin" \
+    -ex "target remote localhost:1234" \
+    -ex "layout asm" \
+    -ex "break _start" \
+    -ex "continue"
+
+# When GDB exits, stop QEMU
+kill $QEMU_PID
+wait $QEMU_PID 2>/dev/null || true


### PR DESCRIPTION
## Summary
- add `scripts/run_with_gdb.sh` to build the project and launch QEMU with gdb
- add `debug` target in `Makefile` to call the script
- document `make debug` in README

## Testing
- `scripts/run_with_gdb.sh` *(fails: `ldc2: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6860dce893588327bc6bb24399cdaa31