### PR TITLE
Separate debug display from GDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ make build
 ```
 
 The resulting ISO image is written to `build/anonymOS.iso`.  Use `make run` to boot it in QEMU.
-For debugging, run `make debug` to build the system, launch QEMU in debug mode and automatically attach GDB.
+For debugging, run `make debug` to build the system, launch QEMU in debug mode and automatically attach GDB.  QEMU
+uses a graphical window so the OS output appears separately from the GDB console.  If you prefer to start GDB
+manually, run `make run-debug` in one terminal and connect with GDB from another using `target remote localhost:1234`.
 
 To include the stock `dmd` compiler in the image, run `./scripts/build_dmd.sh` before `make build`. The script automatically fetches the upstream sources if they are missing and compiles them with your cross-compiled `ldc2`.
 

--- a/scripts/run_with_gdb.sh
+++ b/scripts/run_with_gdb.sh
@@ -8,8 +8,10 @@ cd "$PROJECT_ROOT"
 # Build the system
 make build
 
-# Start QEMU in debug mode
-qemu-system-x86_64 -cdrom build/anonymOS.iso -S -s -m 128M -display curses -vga std &
+# Start QEMU in debug mode.  Use the default graphical display so the
+# emulator output appears in its own window separate from this GDB
+# session.
+qemu-system-x86_64 -cdrom build/anonymOS.iso -S -s -m 128M -vga std &
 QEMU_PID=$!
 
 # Give QEMU time to open the GDB port


### PR DESCRIPTION
## Summary
- show QEMU output in its own window when running `make debug`
- document how to run GDB in a separate terminal

## Testing
- `make build` *(fails: `ldc2` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860e33a70f483278e9aec6ab40bd0ce