### PR TITLE
Add installer entrypoint

### DIFF
--- a/kernel/core/init_stubs.d
+++ b/kernel/core/init_stubs.d
@@ -41,12 +41,12 @@ extern(C) void init_syscall_interface()
 extern(C) void launch_init_process()
 {
     import kernel.process_manager : process_create, scheduler_run;
-    import kernel.shell : ttyShelly_shell;
+    import kernel.shell : install;
     import kernel.logger : log_message, log_hex;
     import kernel.panic : kernel_panic;
     import kernel.types : ErrorCode;
 
-    auto pid = process_create(&ttyShelly_shell);
+    auto pid = process_create(&install);
     if(pid == size_t.max)
     {
         log_message("Failed to create init process\n");

--- a/kernel/shell.d
+++ b/kernel/shell.d
@@ -253,3 +253,15 @@ extern(C) void ttyShelly_shell()
     // Invoke the stub or real Haskell shell if linked.
     ttyShellyMain();
 }
+
+/// Entry point for the system installer process. This runs the minimal
+/// setup steps such as creating the default user and installing the
+/// bundled D compiler before handing control to the interactive shell.
+extern(C) void install()
+{
+    terminal_writestring("Running installer...\r\n");
+    setup_first_user();
+    install_d_compiler();
+    terminal_writestring("Installer finished. Starting shell...\r\n");
+    ttyShellyInteractive();
+}


### PR DESCRIPTION
## Summary
- add an `install` function that performs first-time setup and then drops
  into the interactive shell
- invoke this new `install` process as the first userspace program

## Testing
- `make build` *(fails: `ldc2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861614f37a88327a198036913bb7c47