### PR TITLE
Add logging for init process call

### DIFF
--- a/kernel/process_manager.d
+++ b/kernel/process_manager.d
@@ -79,6 +79,9 @@ extern(C) void scheduler_run()
             log_message("running process ");
             log_hex(p.pid);
             log_message("\n");
+            log_message("entry address=");
+            log_hex(cast(ulong)p.entry);
+            log_message("\n");
             current_pid = p.pid;
             p.entry();
             current_pid = size_t.max;


### PR DESCRIPTION
## Summary
- log the entry address before calling a process in `scheduler_run`

## Testing
- `make kernel_bin` *(fails: `cp: cannot stat 'build/kernel.bin': No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6861627c4b1c8327b8a4d53bf3f162d0