### PR TITLE
Add module fetching script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ ALL_KERNEL_D_OBJS              = $(ALL_KERNEL_D_OBJS_NO_GENERATED) $(ANSI_ART_D_
 ALL_ASM_OBJS      = $(patsubst %.s,$(OBJ_DIR)/%.o,$(ALL_ASM_SOURCES))
 ALL_OBJS          = $(ALL_ASM_OBJS) $(ALL_KERNEL_D_OBJS)
 
-.PHONY: all build clean run iso kernel_bin sh dmd fetch_shell check_shell_support update-run debug
+.PHONY: all build clean run iso kernel_bin sh dmd fetch_shell fetch_modules check_shell_support update-run debug
 
 
 all: $(ISO_FILE)
@@ -136,7 +136,7 @@ iso: $(ISO_FILE)
 build: $(ISO_FILE)
 
 
-$(ISO_FILE): $(KERNEL_BIN) $(DMD_BIN) fetch_shell
+$(ISO_FILE): $(KERNEL_BIN) $(DMD_BIN) fetch_shell fetch_modules
 	@echo ">>> Creating ISO Image..."
 	mkdir -p $(ISO_BOOT_DIR) $(ISO_GRUB_DIR) $(ISO_BIN_DIR) $(ISO_DIR)/third_party $(ISO_DIR)/sys/init
 	cp $(KERNEL_BIN) $(ISO_BOOT_DIR)/
@@ -168,7 +168,7 @@ kernel_bin: $(KERNEL_BIN) # PHONY target now depends on the actual KERNEL_BIN fi
 
 # Ensure ANSI art D file is generated before compiling D sources that might depend on it
 # or before linking if it's directly part of ALL_OBJS (which it is via KERNEL_D_OBJS)
-$(KERNEL_BIN): $(ALL_OBJS) $(LINKER_SCRIPT) | $(BUILD_DIR) # ANSI_ART_D_TARGET_FILE is a dep of its .o file, which is in ALL_OBJS
+$(KERNEL_BIN): fetch_modules $(ALL_OBJS) $(LINKER_SCRIPT) | $(BUILD_DIR) # ANSI_ART_D_TARGET_FILE is a dep of its .o file, which is in ALL_OBJS
 	mkdir -p $(BUILD_DIR)
 	# Removed -lgcc as it's specific to GCC. LDC2/LLD should handle necessary runtime bits or emit self-contained code.
 	$(LD) $(LDFLAGS) -T $(LINKER_SCRIPT) -o $@ $(ALL_OBJS)
@@ -203,6 +203,9 @@ check_shell_support:
 
 fetch_shell:
 	./scripts/fetch_shell.sh
+
+fetch_modules:
+	./scripts/fetch_modules.sh
 
 sh: $(SH_BIN)
 

--- a/README.md
+++ b/README.md
@@ -33,20 +33,11 @@ purpose and now contains the actual sources for that component:
 
 ### Using modules as separate repositories
 
-You can treat each subfolder under `modules/` as an independent Git
-repository. To assemble the full project clone each module into its
-subdirectory (using `git submodule` or manual clones) then run `make` from the
-repository root:
-
-```bash
-git submodule add <microkernel_repo> modules/microkernel
-git submodule add <user_services_repo> modules/user-services
-git submodule add <hypervisor_repo> modules/hypervisor
-git submodule add <containers_repo> modules/containers
-git submodule add <object_tree_repo> modules/object-tree
-git submodule add <distributed_fs_repo> modules/distributed-fs
-make build
-```
+Each folder under `modules/` corresponds to a separate repository hosted on
+GitHub. The build system automatically clones or updates these modules using
+`scripts/fetch_modules.sh` so you no longer need to add them as Git
+submodules manually. Simply run `make build` and the required components will
+be fetched prior to compilation.
 
 
 ## Planned Features

--- a/scripts/fetch_modules.sh
+++ b/scripts/fetch_modules.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+SCRIPT_DIR="$(dirname "$0")"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fetch_repo() {
+    DIR="$1"
+    REPO="$2"
+    if [ ! -d "$PROJECT_ROOT/$DIR/.git" ]; then
+        echo "Cloning $REPO into $DIR"
+        rm -rf "$PROJECT_ROOT/$DIR"
+        git clone --depth 1 "$REPO" "$PROJECT_ROOT/$DIR"
+    else
+        echo "Updating $DIR"
+        git -C "$PROJECT_ROOT/$DIR" pull --ff-only
+    fi
+}
+
+fetch_repo modules/microkernel https://github.com/Jonathan-R-Anderson/anonymos-microkernel.git
+fetch_repo modules/user-services https://github.com/Jonathan-R-Anderson/anonymos-user-services.git
+fetch_repo modules/hypervisor https://github.com/Jonathan-R-Anderson/anonymos-hypervisor.git
+fetch_repo modules/containers https://github.com/Jonathan-R-Anderson/anonymos-containers.git
+fetch_repo modules/object-tree https://github.com/Jonathan-R-Anderson/anonymos-object-tree.git
+fetch_repo modules/distributed-fs https://github.com/Jonathan-R-Anderson/anonymos-distributed-fs.git


### PR DESCRIPTION
## Summary
- fetch external module repos with `scripts/fetch_modules.sh`
- wire module download step into `Makefile`
- document auto fetching of modules in README

## Testing
- `make -n build` *(fails: clone requires auth)*

------
https://chatgpt.com/codex/tasks/task_e_68616a6c924083278d31bd6a233d1579