### PR TITLE
Fix kernel import path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,10 @@ MICROKERNEL_DIR := modules/microkernel
 HYPERVISOR_DIR  := modules/hypervisor
 OBJECT_TREE_DIR := modules/object-tree
 
-       DFLAGS := $(DFLAGS_BASE) $(DFLAGS_TARGET_64) -I. \
-               -I$(MICROKERNEL_DIR)/kernel/include \
-               -I$(HYPERVISOR_DIR) -I$(OBJECT_TREE_DIR)
+   DFLAGS := $(DFLAGS_BASE) $(DFLAGS_TARGET_64) -I. \
+           -I$(MICROKERNEL_DIR) \
+           -I$(MICROKERNEL_DIR)/kernel/include \
+           -I$(HYPERVISOR_DIR) -I$(OBJECT_TREE_DIR)
 	
 # Files and Directories
 ## D Source Files


### PR DESCRIPTION
## Summary
- add `modules/microkernel` to ldc include path so kernel modules can import `kernel.*`

## Testing
- `make run-log-int` *(fails: No rule to make target 'build/obj/modules/hypervisor/hypervisor.o')*

------
https://chatgpt.com/codex/tasks/task_e_68619fe8f364832792e715b06f132d17