### PR TITLE
Fix visibility of shell build helpers

### DIFF
--- a/modules/microkernel/kernel/shell.d
+++ b/modules/microkernel/kernel/shell.d
@@ -98,7 +98,7 @@ private void print_prompt()
 /// Simple first-time setup that installs the non-cross D compiler
 /// and prepares the shell environment. This is only a stub that
 /// prints status messages but represents running the real installer.
-private void build_d_compiler()
+void build_d_compiler()
 {
     import kernel.logger : log_message;
 
@@ -109,7 +109,7 @@ private void build_d_compiler()
     terminal_writestring("D compiler installed.\r\n");
 }
 
-private void build_shell()
+void build_shell()
 {
     import kernel.logger : log_message;
 


### PR DESCRIPTION
## Summary
- expose `build_d_compiler` and `build_shell` so that `main.d` can call them

## Testing
- `make run-log-int` *(fails: modules/microkernel/kernel/thread.d:17: Error: semicolon expected following function declaration)*

------
https://chatgpt.com/codex/tasks/task_e_6861abb52a248327ac63db9e32e98de6