### PR TITLE
Add serial logging

### DIFF
--- a/modules/microkernel/kernel/logger.d
+++ b/modules/microkernel/kernel/logger.d
@@ -14,6 +14,7 @@ else
 {
     import kernel.io : outb;
     import kernel.terminal : terminal_putchar;
+    import kernel.serial : serial_init, serial_putchar;
 
     enum DEBUG_PORT = 0x402; // Simple debug port used for logging
 
@@ -24,6 +25,7 @@ else
         // external monitors while also displaying it on the VGA console for
         // easier debugging when log files are unavailable.
         outb(DEBUG_PORT, cast(ubyte)c);
+        serial_putchar(c);
         terminal_putchar(c);
     }
 }
@@ -34,6 +36,7 @@ __gshared size_t logIndex;
 extern(C) void logger_init()
 {
     import kernel.types : memset;
+    serial_init();
     logIndex = 0;
     // Ensure the entire buffer is zeroed before use
     memset(logBuffer.ptr, 0, logBuffer.length);

--- a/modules/microkernel/kernel/serial.d
+++ b/modules/microkernel/kernel/serial.d
@@ -1,0 +1,26 @@
+module kernel.serial;
+
+pragma(LDC_no_moduleinfo);
+
+import kernel.arch_interface.ports : inb, outb;
+
+public:
+
+enum SERIAL_PORT = 0x3F8; // COM1 base
+
+extern(C) void serial_init()
+{
+    outb(SERIAL_PORT + 1, 0x00); // Disable all interrupts
+    outb(SERIAL_PORT + 3, 0x80); // Enable DLAB
+    outb(SERIAL_PORT + 0, 0x03); // Set baud divisor to 3 (38400 baud)
+    outb(SERIAL_PORT + 1, 0x00); // High byte of divisor
+    outb(SERIAL_PORT + 3, 0x03); // 8 bits, no parity, one stop bit
+    outb(SERIAL_PORT + 2, 0xC7); // Enable FIFO, clear them, 14-byte threshold
+    outb(SERIAL_PORT + 4, 0x0B); // IRQs enabled, RTS/DSR set
+}
+
+extern(C) void serial_putchar(char c)
+{
+    while ((inb(SERIAL_PORT + 5) & 0x20) == 0) {}
+    outb(SERIAL_PORT, cast(ubyte)c);
+}


### PR DESCRIPTION
## Summary
- add a simple serial driver for COM1
- initialize the serial port in the logger
- route log output to the serial port

## Testing
- `make kernel_bin` *(fails: `ldc2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b7b7110c832796a0575999b31eef