### PR TITLE
Fix ISO build copy of shell sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ $(ISO_FILE): $(KERNEL_BIN) $(DMD_BIN) fetch_shell fetch_modules
 	mkdir -p $(ISO_BOOT_DIR) $(ISO_GRUB_DIR) $(ISO_BIN_DIR) $(ISO_DIR)/third_party $(ISO_DIR)/sys/init
 	cp $(KERNEL_BIN) $(ISO_BOOT_DIR)/
 	cp $(DMD_BIN) $(ISO_BIN_DIR)/
-	cp -r third_party/sh $(ISO_DIR)/third_party/
+	rsync -a --exclude='.git' third_party/sh/ $(ISO_DIR)/third_party/sh/
 	cp scripts/install_shell_in_os.sh $(ISO_DIR)/sys/init/
 			# Critical: Ensure the backslash '\' after 'then' on the line below
 		# is the *absolute last character* on that line. No trailing spaces.


### PR DESCRIPTION
## Summary
- avoid copying `.git` when adding shell sources to ISO

## Testing
- `make build` *(fails: `ldc2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861bad239b483278c2bb527a5a027f2