### PR TITLE
Fix keyboard logger import

### DIFF
--- a/modules/microkernel/kernel/keyboard.d
+++ b/modules/microkernel/kernel/keyboard.d
@@ -4,6 +4,7 @@ module kernel.keyboard;
 import kernel.terminal : terminal_writestring, terminal_putchar;
 import kernel.lib.stdc.stdint; // Use local stdint stub
 import kernel.arch_interface.ports : inb, outb; // Direct port access
+import kernel.logger : log_message; // For debug logging
 
 // If needed for more direct keyboard controller interaction:
 // extern (C) {


### PR DESCRIPTION
## Summary
- include the `kernel.logger` module so that `keyboard.d` compiles again

## Testing
- `ldc2 -betterC -O1 -g -boundscheck=off -output-o -mtriple=x86_64-unknown-elf -mcpu=x86-64 -I. -Imodules/microkernel -Imodules/microkernel/kernel/include -Imodules/hypervisor -Imodules/object-tree -c modules/microkernel/kernel/keyboard.d -of=/tmp/keyboard.o`

------
https://chatgpt.com/codex/tasks/task_e_6861d5deb9c483278066b4b5817d02f7