### PR TITLE
package d compiler sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,13 @@ format `user@namespace:/path(permission)`.
 The ISO packages the shell sources in `/third_party/sh` along with a helper
 script `install_shell_in_os.sh` located in `/sys/init`.  After installation the
 system automatically runs this installer which builds the shell using the
-bundled native `dmd` compiler and installs it to `/bin/sh`.  This keeps the raw
-sources available while deferring compilation to the installed environment.
+bundled native `dmd` compiler and installs it to `/bin/sh`.  The D compiler
+sources are also copied to `/third_party/dmd` with a companion script
+`install_dmd_in_os.sh`. During the initial setup this script builds the native
+compiler inside anonymOS so the shell compilation happens entirely within the
+OS environment.
+This keeps the raw sources available while deferring compilation to the
+installed system.
 
 ## Object Namespace Overview
 

--- a/scripts/check_shell_support.sh
+++ b/scripts/check_shell_support.sh
@@ -4,8 +4,8 @@ set -e
 SCRIPT_DIR="$(dirname "$0")"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-terminal_file="$PROJECT_ROOT/kernel/terminal.d"
-keyboard_file="$PROJECT_ROOT/kernel/keyboard.d"
+terminal_file="$PROJECT_ROOT/modules/microkernel/kernel/terminal.d"
+keyboard_file="$PROJECT_ROOT/modules/microkernel/kernel/keyboard.d"
 
 echo "Checking shell support..."
 

--- a/scripts/fetch_dmd.sh
+++ b/scripts/fetch_dmd.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+SCRIPT_DIR="$(dirname "$0")"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DMD_DIR="$PROJECT_ROOT/third_party/dmd"
+REPO_URL="https://github.com/dlang/dmd.git"
+
+if [ ! -d "$DMD_DIR/.git" ]; then
+    mkdir -p "$PROJECT_ROOT/third_party"
+    git clone --depth 1 "$REPO_URL" "$DMD_DIR"
+else
+    git -C "$DMD_DIR" pull --ff-only
+fi

--- a/scripts/install_dmd_in_os.sh
+++ b/scripts/install_dmd_in_os.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Build the DMD compiler inside anonymOS using the bundled D compiler.
+set -e
+SRC_DIR="/third_party/dmd"
+DMD="/bin/dmd"
+OUT="/bin/dmd"
+
+if [ ! -x "$DMD" ]; then
+    echo "dmd compiler not found at $DMD" >&2
+    exit 1
+fi
+
+if [ ! -d "$SRC_DIR" ]; then
+    echo "DMD sources not found at $SRC_DIR" >&2
+    exit 1
+fi
+
+cd "$SRC_DIR"
+echo "Compiling DMD..."
+make -f posix.mak AUTO_BOOTSTRAP=1 MODEL=64 > /tmp/dmd_build.log 2>&1
+cp generated/linux/release/64/dmd "$OUT"
+echo "DMD installed to $OUT"


### PR DESCRIPTION
## Summary
- ship dmd source and bootstrap scripts with the ISO
- update README to document that dmd and sh are built inside the OS
- drop host shell build rule and provide fetch_dmd helper

## Testing
- `scripts/check_shell_support.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861d88cc568832793fe34e6409e10cb