### PR TITLE
Fix makefile indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,12 +141,12 @@ build: $(ISO_FILE)
 $(ISO_FILE): $(KERNEL_BIN) $(DMD_BIN) fetch_shell fetch_dmd fetch_modules
 	@echo ">>> Creating ISO Image..."
 	mkdir -p $(ISO_BOOT_DIR) $(ISO_GRUB_DIR) $(ISO_BIN_DIR) $(ISO_DIR)/third_party $(ISO_DIR)/sys/init
-       cp $(KERNEL_BIN) $(ISO_BOOT_DIR)/
-       cp $(DMD_BIN) $(ISO_BIN_DIR)/
-       rsync -a --exclude='.git' third_party/sh/ $(ISO_DIR)/third_party/sh/
-       rsync -a --exclude='.git' $(DMD_SRC_DIR)/ $(ISO_DIR)/third_party/dmd/
-       cp scripts/install_shell_in_os.sh $(ISO_DIR)/sys/init/
-       cp scripts/install_dmd_in_os.sh $(ISO_DIR)/sys/init/
+	cp $(KERNEL_BIN) $(ISO_BOOT_DIR)/
+	cp $(DMD_BIN) $(ISO_BIN_DIR)/
+	rsync -a --exclude='.git' third_party/sh/ $(ISO_DIR)/third_party/sh/
+	rsync -a --exclude='.git' $(DMD_SRC_DIR)/ $(ISO_DIR)/third_party/dmd/
+	cp scripts/install_shell_in_os.sh $(ISO_DIR)/sys/init/
+	cp scripts/install_dmd_in_os.sh $(ISO_DIR)/sys/init/
 			# Critical: Ensure the backslash '\' after 'then' on the line below
 		# is the *absolute last character* on that line. No trailing spaces.
 		# This is the most common cause for the "expecting fi" error on "line 2".
@@ -199,13 +199,13 @@ $(DMD_BIN): | $(BUILD_DIR)
 dmd: $(DMD_BIN)
 
 fetch_shell:
-       ./scripts/fetch_shell.sh
+	       ./scripts/fetch_shell.sh
 
 fetch_modules:
-       ./scripts/fetch_modules.sh
+	       ./scripts/fetch_modules.sh
 
 fetch_dmd:
-       ./scripts/fetch_dmd.sh
+	       ./scripts/fetch_dmd.sh
 
 run: $(ISO_FILE)
 	qemu-system-x86_64 -cdrom $(ISO_FILE) -m 128M -display curses -vga std


### PR DESCRIPTION
## Summary
- fix indentation lines in Makefile for cp/rsync commands
- fix fetch targets indentation so `make run-debug` executes

## Testing
- `make run-debug` *(fails to complete build but no `missing separator` error)*

------
https://chatgpt.com/codex/tasks/task_e_6861e236576083279ada62e766ccc4b6