### PR TITLE
Fix EntryFunc import

### DIFF
--- a/modules/microkernel/kernel/shell.d
+++ b/modules/microkernel/kernel/shell.d
@@ -258,7 +258,7 @@ extern(C) void sh_shell()
 {
     import kernel.logger : log_message;
     import kernel.elf_loader : load_elf;
-    import kernel.process_manager : process_create, scheduler_run;
+    import kernel.process_manager : process_create, scheduler_run, EntryFunc;
 
     // After build_shell() the compiled binary should reside at /bin/sh
     void* entry = null;


### PR DESCRIPTION
## Summary
- import `EntryFunc` in `kernel.shell` so the build won't fail

## Testing
- `make run-debug` *(fails: `ldc2: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6862057ed9808327a2a5bd0427c60248