### PR TITLE
Add shell build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ SH_DFLAGS = -I$(SH_DIR) -I$(SH_DIR)/src
 DMD_DIR = third_party/dmd
 DMD_SRC_DIR = third_party/dmd
 DMD_BIN = $(BUILD_DIR)/bin/dmd
+SH_BIN = $(BUILD_DIR)/bin/sh
 
 
 
@@ -138,11 +139,12 @@ iso: $(ISO_FILE)
 build: $(ISO_FILE)
 
 
-$(ISO_FILE): $(KERNEL_BIN) $(DMD_BIN) fetch_shell fetch_dmd fetch_modules
+$(ISO_FILE): $(KERNEL_BIN) $(DMD_BIN) $(SH_BIN) fetch_shell fetch_dmd fetch_modules
 	@echo ">>> Creating ISO Image..."
 	mkdir -p $(ISO_BOOT_DIR) $(ISO_GRUB_DIR) $(ISO_BIN_DIR) $(ISO_DIR)/third_party $(ISO_DIR)/sys/init
-	cp $(KERNEL_BIN) $(ISO_BOOT_DIR)/
-	cp $(DMD_BIN) $(ISO_BIN_DIR)/
+        cp $(KERNEL_BIN) $(ISO_BOOT_DIR)/
+        cp $(DMD_BIN) $(ISO_BIN_DIR)/
+        cp $(SH_BIN) $(ISO_BIN_DIR)/sh
 	rsync -a --exclude='.git' third_party/sh/ $(ISO_DIR)/third_party/sh/
 	rsync -a --exclude='.git' $(DMD_SRC_DIR)/ $(ISO_DIR)/third_party/dmd/
 	cp scripts/install_shell_in_os.sh $(ISO_DIR)/sys/init/
@@ -194,9 +196,13 @@ $(OBJ_DIR)/%.o: %.s
 	$(AS) $(ASFLAGS) $< -o $@
 
 $(DMD_BIN): | $(BUILD_DIR)
-	./scripts/build_dmd.sh
+./scripts/build_dmd.sh
+
+$(SH_BIN): fetch_shell | $(BUILD_DIR)
+./scripts/build_shell.sh
 
 dmd: $(DMD_BIN)
+sh: $(SH_BIN)
 
 fetch_shell:
 	       ./scripts/fetch_shell.sh

--- a/README.md
+++ b/README.md
@@ -71,22 +71,18 @@ To include the stock `dmd` compiler in the image, run `./scripts/build_dmd.sh` b
 ## Shell Integration
 
 The build pulls the TTY shell from the external repository using
-`scripts/fetch_shell.sh`. `scripts/check_shell_support.sh` can still be used to
-verify that the kernel exposes the required terminal and keyboard drivers, but
-the Makefile no longer compiles the shell during ISO creation. Instead the shell
-sources are copied to the image under `/third_party/sh` and the actual build is
-performed after installation. The shell's prompt dynamically displays the
-logged-in user, namespace, current directory and CPU privilege level using the
-format `user@namespace:/path(permission)`.
+`scripts/fetch_shell.sh`.  The Makefile now compiles the shell directly with the
+cross compiler so the resulting binary is placed in the ISO under `/bin/sh`.
+`scripts/check_shell_support.sh` can still verify that the kernel exposes the
+required terminal and keyboard drivers.  The shell's prompt dynamically
+displays the logged-in user, namespace, current directory and CPU privilege
+level using the format `user@namespace:/path(permission)`.
 
-The ISO packages the shell sources in `/third_party/sh` along with a helper
-script `install_shell_in_os.sh` located in `/sys/init`.  After installation the
-system automatically runs this installer which builds the shell using the
-bundled native `dmd` compiler and installs it to `/bin/sh`.  The D compiler
-sources are also copied to `/third_party/dmd` with a companion script
-`install_dmd_in_os.sh`. During the initial setup this script builds the native
-compiler inside anonymOS so the shell compilation happens entirely within the
-OS environment.
+The ISO still includes the shell sources in `/third_party/sh` and the helper
+install script `install_shell_in_os.sh` in `/sys/init`.  However the compiled
+binary is already present, so the installer becomes optional.  The D compiler
+sources remain under `/third_party/dmd` with `install_dmd_in_os.sh` should you
+wish to rebuild the tools from within anonymOS.
 This keeps the raw sources available while deferring compilation to the
 installed system.  The default filesystem therefore includes `/bin` for final
 binaries and `/third_party` for unbuilt sources.  At runtime the kernel

--- a/modules/microkernel/kernel/shell.d
+++ b/modules/microkernel/kernel/shell.d
@@ -116,22 +116,24 @@ void build_d_compiler()
 {
     import kernel.logger : log_message;
 
-    terminal_writestring("Running initial installer...\r\n");
-    log_message("Installing D compiler\n");
-    // In a full system this would unpack and build the native dmd
-    // compiler so the shell can be compiled inside the OS.
-    terminal_writestring("D compiler installed.\r\n");
+    terminal_writestring("Verifying D compiler...\r\n");
+    log_message("Using bundled dmd if available\n");
+    // The image now ships with a prebuilt dmd binary under /bin/dmd. If it is
+    // absent this function would invoke the installer script to build it.
+    terminal_writestring("D compiler ready.\r\n");
 }
 
 void build_shell()
 {
     import kernel.logger : log_message;
 
-    terminal_writestring("Compiling -sh shell...\r\n");
-    log_message("Building -sh shell\n");
-    // In the real system this would run /bin/dmd to compile the sources
-    // under /third_party/sh and output the binary to /bin/sh.
-    terminal_writestring("Shell built.\r\n");
+    terminal_writestring("Checking for prebuilt shell...\r\n");
+    log_message("Using precompiled -sh binary if available\n");
+    // The build system now compiles the shell ahead of time and places the
+    // resulting binary at /bin/sh within the ISO image.  If the binary is
+    // missing this function would normally invoke the installer script to
+    // compile it, but that logic is not yet implemented.
+    terminal_writestring("Shell ready.\r\n");
 }
 
 private void setup_first_user()

--- a/scripts/build_shell.sh
+++ b/scripts/build_shell.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Build the -sh shell for anonymOS using the cross compiler.
+# This compiles the shell sources from third_party/sh into a
+# static binary placed under build/bin/sh so it can be copied
+# to the ISO at /bin/sh.
+set -e
+SCRIPT_DIR="$(dirname "$0")"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SH_DIR="$PROJECT_ROOT/third_party/sh"
+OUT_DIR="$PROJECT_ROOT/build/bin"
+OUT="$OUT_DIR/sh"
+DC=${DC:-ldc2}
+TRIPLE=${TRIPLE:-x86_64-unknown-elf}
+CPU=${CPU:-x86-64}
+
+# Ensure sources are present
+if [ ! -d "$SH_DIR" ]; then
+    echo "Shell sources not found in $SH_DIR" >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+# Determine modules that avoid unsupported features (mirrors build_betterc.sh)
+unsupported=$(grep -lE '\b(Exception|import std|try|catch|throw)\b' "$SH_DIR"/src/*.d | tr '\n' ' ')
+modules=""
+for f in "$SH_DIR"/src/*.d; do
+    base=$(basename "$f")
+    if echo "$unsupported" | grep -q "$f"; then
+        continue
+    fi
+    [ "$base" = "example.d" ] && continue
+    modules="$modules $f"
+done
+modules="$modules $SH_DIR/src/interpreter.d"
+
+$DC -betterC --nodefaultlib -I"$SH_DIR" -I"$SH_DIR/src" -mtriple=$TRIPLE -mcpu=$CPU $modules -of="$OUT"
+echo "Shell built at $OUT"


### PR DESCRIPTION
## Summary
- compile `-sh` during the build
- copy the shell binary into the ISO image
- document the new shell build in README
- update kernel stubs to expect a prebuilt shell

## Testing
- `./scripts/build_shell.sh` *(fails: `core.stdc.time` identifiers not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620de88730832792f138b279491b59