### PR TITLE
Fix Makefile indentation for fetch shell rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,16 +200,16 @@ $(DMD_BIN): | $(BUILD_DIR)
 	./scripts/build_dmd.sh
 
 $(SH_BIN): fetch_shell fetch_posix | $(BUILD_DIR)
-        ./scripts/build_shell.sh
+	./scripts/build_shell.sh
 
 dmd: $(DMD_BIN)
 sh: $(SH_BIN)
 
 fetch_shell:
-               ./scripts/fetch_shell.sh
+	./scripts/fetch_shell.sh
 
 fetch_posix:
-               ./scripts/fetch_posix.sh
+	./scripts/fetch_posix.sh
 
 fetch_modules:
 	       ./scripts/fetch_modules.sh


### PR DESCRIPTION
## Summary
- fix indentation on shell-related build rules to use tabs

## Testing
- `make run-debug` *(fails: `ldc2` not found, but Makefile parses)*

------
https://chatgpt.com/codex/tasks/task_e_68622c35d1ac8327a5f271d07379c871