### PR TITLE
Fix fetch_posix.sh for existing directories

### DIFF
--- a/scripts/fetch_posix.sh
+++ b/scripts/fetch_posix.sh
@@ -6,6 +6,10 @@ POSIX_DIR="$PROJECT_ROOT/third_party/posix"
 REPO_URL="https://github.com/Jonathan-R-Anderson/anonymos-posix.git"
 if [ ! -d "$POSIX_DIR/.git" ]; then
     mkdir -p "$PROJECT_ROOT/third_party"
+    if [ -d "$POSIX_DIR" ] && [ "$(ls -A "$POSIX_DIR" 2>/dev/null)" ]; then
+        echo "Removing existing non-git directory $POSIX_DIR"
+        rm -rf "$POSIX_DIR"
+    fi
     git clone --depth 1 "$REPO_URL" "$POSIX_DIR"
 else
     git -C "$POSIX_DIR" pull --ff-only


### PR DESCRIPTION
## Summary
- handle pre-existing third_party/posix directory in `fetch_posix.sh`

## Testing
- `make run-debug`

------
https://chatgpt.com/codex/tasks/task_e_68622d3f9c4883278587e6d88da35714