### PR TITLE
Update DMD build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,14 @@ compilation.
 
 ## Building
 
-Prerequisites include `grub-mkrescue`, `xorriso` and the `ldc2` D compiler.  Run `scripts/setup_dev_env.sh` first to fetch the POSIX wrappers along with the `dmd` compiler and `-sh` shell sources.  These tools are compiled inside anonymOS after boot.  Then build the system with:
+Install `grub-mkrescue`, `xorriso` and the `ldc2` D compiler using your package
+manager.  Once these prerequisites are in place run
+`scripts/setup_dev_env.sh` to download the POSIX wrapper library, the DMD source
+code and the `-sh` shell.  The build system automatically produces a bootstrap
+`dmd` binary via `scripts/build_dmd.sh`.  This compiler relies on the POSIX
+wrappers for its system calls, so after booting anonymOS you must run
+`/sys/init/install_posix_in_os.sh` before rebuilding the full toolchain.  With
+everything fetched you can build the ISO image with:
 
 ```bash
 make build

--- a/scripts/build_dmd.sh
+++ b/scripts/build_dmd.sh
@@ -11,8 +11,21 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 DMD_DIR="$PROJECT_ROOT/third_party/dmd"
 BIN_DIR="$PROJECT_ROOT/build/bin"
+POSIX_DIR="$PROJECT_ROOT/third_party/posix"
 HOST_DMD=${HOST_DMD:-ldmd2}
 JOBS=${JOBS:-$(nproc)}
+
+# Ensure the host D compiler is available
+if ! command -v "$HOST_DMD" >/dev/null 2>&1; then
+    echo "Host D compiler '$HOST_DMD' not found. Install ldc2 or set HOST_DMD." >&2
+    exit 1
+fi
+
+# Ensure the POSIX wrappers are present since the compiler depends on them
+if [ ! -d "$POSIX_DIR" ]; then
+    echo "POSIX wrappers missing at $POSIX_DIR. Run scripts/fetch_posix.sh first." >&2
+    exit 1
+fi
 
 # Fetch the dmd sources if they are missing
 if [ ! -d "$DMD_DIR/.git" ]; then


### PR DESCRIPTION
## Summary
- clarify toolchain setup and note POSIX wrappers
- verify POSIX sources in build script

## Testing
- `./scripts/build_dmd.sh` *(fails: Host D compiler 'ldmd2' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68623e7b128c8327857342b233fd71b4