### PR TITLE
Ensure remote dependencies pulled from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,15 @@ compilation.
 
 ## Building
 
-Prerequisites include `grub-mkrescue`, `xorriso` and the `ldc2` D compiler.  Run `scripts/setup_dev_env.sh` first to fetch the POSIX wrappers along with the `dmd` compiler and `-sh` shell sources.  These tools are compiled inside anonymOS after boot.  Then build the system with:
+Prerequisites include `grub-mkrescue`, `xorriso` and the `ldc2` D compiler.  Run
+`scripts/setup_dev_env.sh` first to fetch the POSIX wrappers and shell sources
+directly from their GitHub repositories:
+
+- [anonymos-posix](https://github.com/Jonathan-R-Anderson/anonymos-posix)
+- [\-sh](https://github.com/Jonathan-R-Anderson/-sh)
+
+These external components are compiled inside anonymOS after boot.  Then build
+the system with:
 
 ```bash
 make build

--- a/scripts/fetch_posix.sh
+++ b/scripts/fetch_posix.sh
@@ -3,7 +3,8 @@ set -e
 SCRIPT_DIR="$(dirname "$0")"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 POSIX_DIR="$PROJECT_ROOT/third_party/posix"
-REPO_URL="https://github.com/Jonathan-R-Anderson/anonymos-posix.git"
+# Repository providing the POSIX wrappers used by anonymOS
+REPO_URL="https://github.com/Jonathan-R-Anderson/anonymos-posix"
 if [ ! -d "$POSIX_DIR/.git" ]; then
     mkdir -p "$PROJECT_ROOT/third_party"
     if [ -d "$POSIX_DIR" ] && [ "$(ls -A "$POSIX_DIR" 2>/dev/null)" ]; then

--- a/scripts/fetch_shell.sh
+++ b/scripts/fetch_shell.sh
@@ -3,7 +3,8 @@ set -e
 SCRIPT_DIR="$(dirname "$0")"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SH_DIR="$PROJECT_ROOT/third_party/sh"
-REPO_URL="https://github.com/Jonathan-R-Anderson/-sh.git"
+# Repository for the interactive shell included with anonymOS
+REPO_URL="https://github.com/Jonathan-R-Anderson/-sh"
 if [ ! -d "$SH_DIR/.git" ]; then
     mkdir -p "$PROJECT_ROOT/third_party"
     git clone --depth 1 "$REPO_URL" "$SH_DIR"


### PR DESCRIPTION
## Summary
- clarify in README that dependencies are fetched from their GitHub repos
- update fetch scripts to use the GitHub URLs without `.git`

## Testing
- `bash -n scripts/fetch_posix.sh`
- `bash -n scripts/fetch_shell.sh`


------
https://chatgpt.com/codex/tasks/task_e_686247e0064c8327be49c870427e77da