### PR TITLE
Update run-log-int rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,9 +129,9 @@ run-debug: $(ISO_FILE)
 	$(QEMU) -cdrom $< $(QEMU_FLAGS) -S -s
 
 run-log-int: $(ISO_FILE)
-	$(QEMU) -cdrom $< $(QEMU_FLAGS) -m 512M -display none \
+	$(QEMU) -cdrom $< -m 512M -serial stdio -display none \
 	   -d int,guest_errors,cpu_reset -D qemu.log \
-	   -serial stdio -monitor none -M smm=off -no-reboot
+	   -monitor none -M smm=off -no-reboot
 
 # ─────────────── Shell binary ─────────────────
 SH_BIN := $(BUILD_DIR)/bin/sh


### PR DESCRIPTION
## Summary
- update `run-log-int` QEMU command so it matches the settings used for a clean boot

## Testing
- `make update-run` *(fails: `ldc2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864bae13fac832780e4bef889775eb0