### PR TITLE
Fix invalid parent in process_manager

### DIFF
--- a/kernel/kernel/process_manager.d
+++ b/kernel/kernel/process_manager.d
@@ -55,6 +55,9 @@ extern(C) size_t process_create_with_parent(EntryFunc entry, size_t parent)
     if(g_process_count >= g_processes.length)
         return size_t.max;
     size_t pid = g_process_count;
+
+    if(parent >= g_process_count)
+        parent = size_t.max;
     
     size_t stack_size = DEFAULT_STACK_SIZE;
     ubyte* user_stack = cast(ubyte*)malloc(stack_size);


### PR DESCRIPTION
## Summary
- guard against invalid parent PIDs in `process_create_with_parent`

## Testing
- `make update-run` *(fails: `ldc2` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6864be2a3b3083279f59145e810a3f7d