### PR TITLE
Fix process stack alignment

### DIFF
--- a/kernel/kernel/process_manager.d
+++ b/kernel/kernel/process_manager.d
@@ -101,7 +101,11 @@ private extern(C) void call_on_process_stack(EntryFunc fn, ubyte* stack, size_t 
     // Save current stack pointer
     asm { "mov %%rsp, %0" : "=r"(oldRsp); };
     // Switch to the top of the provided stack
+    // Reserve a small red zone for the return address
+    // and align the pointer down to 16 bytes as per SysV ABI
     auto newRsp = cast(ulong)(stack + stackSize);
+    newRsp &= ~cast(ulong)0xF;
+    newRsp -= 16;
     asm { "mov %0, %%rsp" : : "r"(newRsp); };
     fn();
     // Restore original stack pointer


### PR DESCRIPTION
## Summary
- align the allocated process stack to 16 bytes and reserve space for the return address when switching stacks

## Testing
- `make build` *(fails: ldc2: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6864c42ba93c8327be4b939e29934822