### PR TITLE
Add quickstart make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ASM_OBJS := $(patsubst %.s,$(OBJ_DIR)/%.o,$(ASM_SOURCES))
 OBJS     := $(D_OBJS) $(ASM_OBJS)
 
 # ─────────────── Phony targets ─────────────────
-.PHONY: all iso build clean run run-debug run-log-int fsimg update-run
+.PHONY: all iso build clean run run-debug run-log-int fsimg update-run quickstart
 
 all: $(ISO_FILE)
 iso: all
@@ -145,6 +145,12 @@ $(SH_BIN): scripts/build_sh_bin.sh third_party/stub_shell.d third_party/sh/build
 # ─────────────── Convenience target ──────────
 update-run: $(ISO_FILE)
 	@echo "Build complete – QEMU run skipped in automated environment."
+
+# ─────────────── All-in-one helper ─────────────
+quickstart:
+	@bash scripts/setup_dev_env.sh
+	@bash scripts/build_dmd.sh
+	$(MAKE) run-log-int
 
 # ─────────────── House-keeping ──────────────────
 clean:

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,16 @@ the system with:
 make build
 ```
 
+To fetch the external sources, build the D compiler, create the ISO and boot
+the system in one step, run:
+
+```bash
+make quickstart
+```
+
+This command launches QEMU with logging enabled using the same parameters as the
+`run-log-int` target.
+
 The resulting ISO image is written to `build/anonymOS.iso`.  Use `make run` to boot it in QEMU.
 For debugging, run `make debug` to build the system, launch QEMU in debug mode and automatically attach GDB.  QEMU
 uses a graphical window so the OS output appears separately from the GDB console.  If you prefer to start GDB


### PR DESCRIPTION
## Summary
- create `quickstart` target to automate fetching sources, building DMD, compiling the ISO and booting QEMU
- document the `make quickstart` command in the build instructions

## Testing
- `make quickstart -n | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6864d87a10588327b46c18525c292106