### PR TITLE
Fix DMD fetch and build scripts

### DIFF
--- a/scripts/build_dmd.sh
+++ b/scripts/build_dmd.sh
@@ -14,7 +14,7 @@ JOBS=${JOBS:-$(nproc)}
 "$SCRIPT_DIR/fetch_dmd.sh"
 
 mkdir -p "$BIN_DIR"
-make -C "$DMD_DIR" -f Makefile -j$JOBS HOST_DMD="$HOST_DMD" ENABLE_RELEASE=1
-cp "$DMD_DIR/generated/linux/release/64/dmd" "$BIN_DIR/dmd"
+make -C "$DMD_DIR" -f powernex.mak -j$JOBS HOST_DMD="$HOST_DMD" ENABLE_RELEASE=1
+cp "$DMD_DIR/generated/powernex/release/64/dmd" "$BIN_DIR/dmd"
 
 echo "DMD built and copied to $BIN_DIR/dmd"

--- a/scripts/fetch_dmd.sh
+++ b/scripts/fetch_dmd.sh
@@ -20,11 +20,12 @@ else
     echo "Updating DMD repository..."
     git -C "$DMD_DIR" fetch origin
     git -C "$DMD_DIR" fetch --tags
-    git -C "$DMD_DIR" reset --hard origin/master
 fi
 
 if [ -n "$VERSION" ]; then
     git -C "$DMD_DIR" checkout "$VERSION"
+else
+    git -C "$DMD_DIR" reset --hard origin/master
 fi
 
 if [ -d "$PATCH_DIR" ]; then

--- a/scripts/install_dmd_in_os.sh
+++ b/scripts/install_dmd_in_os.sh
@@ -19,6 +19,6 @@ fi
 
 cd "$SRC_DIR"
 echo "Compiling DMD..."
-make -f posix.mak AUTO_BOOTSTRAP=1 MODEL=64 > /tmp/dmd_build.log 2>&1
-cp generated/linux/release/64/dmd "$OUT"
+make -f powernex.mak AUTO_BOOTSTRAP=1 MODEL=64 > /tmp/dmd_build.log 2>&1
+cp generated/powernex/release/64/dmd "$OUT"
 echo "DMD installed to $OUT"


### PR DESCRIPTION
## Summary
- update scripts to use the PowerNex makefile
- handle DMD version checkout correctly

## Testing
- `bash -x scripts/fetch_dmd.sh`
- `make quickstart` *(fails: `ldmd2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864daabd4908327a6b8ef567df022d8