### PR TITLE
Add function name logging

### DIFF
--- a/kernel/kernel/core/main.d
+++ b/kernel/kernel/core/main.d
@@ -195,7 +195,7 @@ extern (C) void kmain(void* multiboot_info_ptr) {
     clear_screen();
 
     log_message("All subsystems (stubs) initialized. Launching built-in shell early.\n");
-    process_create(&sh_shell);
+    process_create(&sh_shell, "sh_shell");
     scheduler_run();
     loop_forever_hlt();
 

--- a/kernel/kernel/lib/stdc/stdlib.d
+++ b/kernel/kernel/lib/stdc/stdlib.d
@@ -189,7 +189,7 @@ extern(C) int system(const(char)* cmd)
     // launched via either "shell" or "sh".
     if(str_eq(cmd, "shell") || str_eq(cmd, "sh"))
     {
-        process_create(&sh_shell);
+        process_create(&sh_shell, "sh_shell");
         scheduler_run();
         return 0;
     }

--- a/kernel/kernel/syscall.d
+++ b/kernel/kernel/syscall.d
@@ -217,7 +217,7 @@ enum RForkFlags : ulong { RFPROC = 1 }
 extern(C) long sys_rfork(ulong flags, ulong, ulong, ulong, ulong, ulong)
 {
     size_t pid = get_current_pid();
-    size_t child = process_create_with_parent(g_processes[pid].entry, pid);
+    size_t child = process_create_with_parent(g_processes[pid].entry, pid, g_processes[pid].name);
     if(child == size_t.max)
     {
         auto msg = "rfork failed";
@@ -241,7 +241,7 @@ extern(C) long sys_exec(ulong pathPtr, ulong argvPtr, ulong, ulong, ulong, ulong
         return -1;
     }
     size_t parent = get_current_pid();
-    auto child = process_create_with_parent(cast(EntryFunc)entry, parent);
+    auto child = process_create_with_parent(cast(EntryFunc)entry, parent, path);
     if(child == size_t.max)
     {
         auto msg = "exec failed";


### PR DESCRIPTION
## Summary
- log function names when switching stacks
- pass name to process manager when creating processes
- plumb process names through rfork/exec

## Testing
- `make update-run` *(fails: `ldc2: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_686501dc86a88327837ce81486715545