### PR TITLE
Fix strcasecmp const modification

### DIFF
--- a/kernel/kernel/lib/stdc/string.d
+++ b/kernel/kernel/lib/stdc/string.d
@@ -38,8 +38,8 @@ extern(C) int strcmp(const char* a, const char* b) {
 extern(C) int strcasecmp(const char* a, const char* b) {
     size_t i = 0;
     while (a[i] && b[i]) {
-        auto ca = a[i];
-        auto cb = b[i];
+        char ca = cast(char)a[i];
+        char cb = cast(char)b[i];
         // simple ASCII lowercase conversion
         if (ca >= 'A' && ca <= 'Z') ca += 32;
         if (cb >= 'A' && cb <= 'Z') cb += 32;


### PR DESCRIPTION
## Summary
- prevent attempts to modify const chars in `strcasecmp`

## Testing
- `make build` *(fails: unable to read module `file` during build)*

------
https://chatgpt.com/codex/tasks/task_e_6865709a80648327b89b95cdf1d730c8