### PR TITLE
Fix missing shell imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ DFLAGS           = $(DFLAGS_BASE) $(DFLAGS_TARGET_64) \
                    -I$(MICROKERNEL_DIR)/kernel \
                    -I$(MICROKERNEL_DIR)/kernel/include \
                    -I$(HYPERVISOR_DIR) \
-                   -I$(OBJECT_TREE_DIR)
+                   -I$(OBJECT_TREE_DIR) \
+                   -Ithird_party/sh \
+                   -Ithird_party/sh/src
 
 ASFLAGS  = --64
 LDFLAGS  = -nostdlib -no-pie


### PR DESCRIPTION
## Summary
- include the interactive shell sources in the compiler search path

## Testing
- `make build -j2` *(fails: `ldc2` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686571f2f6b08327843acb5c14215265