### PR TITLE
Fix module declaration for shell

### DIFF
--- a/kernel/kernel/shell.d
+++ b/kernel/kernel/shell.d
@@ -1,3 +1,5 @@
+module kernel.shell;
+
 import mstd.stdio;
 import mstd.string;
 import mstd.array;


### PR DESCRIPTION
## Summary
- add missing `module kernel.shell` declaration

## Testing
- `make -j2` *(fails: unable to read module due to missing cross-compile environment)*

------
https://chatgpt.com/codex/tasks/task_e_68657403e5cc832796a7fffa9b6d3365