### PR TITLE
Add stub exit & art script, update build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ DFLAGS           = $(DFLAGS_BASE) $(DFLAGS_TARGET_64) \
                    -I$(MICROKERNEL_DIR)/kernel/include \
                    -I$(HYPERVISOR_DIR) \
                    -I$(OBJECT_TREE_DIR) \
+                   -Iuserspace/anonlib \
                    -Ithird_party/sh \
                    -Ithird_party/sh/src
 

--- a/kernel/kernel/lib/stdc/stdlib.d
+++ b/kernel/kernel/lib/stdc/stdlib.d
@@ -3,7 +3,11 @@ module kernel.lib.stdc.stdlib;
 // Use our own minimal memcpy implementation to avoid
 // pulling in external C runtime dependencies.
 import kernel.types : memcpy, strlen, memcmp;
-import kernel.process_manager : process_create, scheduler_run;
+import kernel.process_manager :
+    process_create,
+    scheduler_run,
+    process_exit,
+    get_current_pid;
 import kernel.shell : sh_shell;
 import kernel.logger : log_message, log_hex;
 
@@ -196,5 +200,13 @@ extern(C) int system(const(char)* cmd)
 
     // Command not recognized
     return -1;
+}
+
+extern(C) @noreturn void exit(int status)
+{
+    auto pid = get_current_pid();
+    process_exit(pid, status);
+    scheduler_run();
+    while(true) asm { "hlt"; }
 }
 

--- a/kernel/kernel/shell.d
+++ b/kernel/kernel/shell.d
@@ -9,7 +9,7 @@ import mstd.range;
 import mstd.file : chdir, getcwd, dirEntries, SpanMode, readText,
     copy, rename, remove, mkdir, rmdir, exists;
 import mstd.process : environment;
-import core.stdc.stdlib : system;
+import kernel.lib.stdc.stdlib : system;
 version(Posix) import core.sys.posix.unistd : execvp;
 version(Posix) extern(C) int chroot(const char* path);
 import mstd.regex : regex, matchFirst;
@@ -797,7 +797,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         }
         version(Posix) {
             import mstd.string : toStringz;
-            import core.stdc.stdlib : exit;
+            import kernel.lib.stdc.stdlib : exit;
             const(char)*[] args;
             foreach(t; tokens[1 .. $]) args ~= t.toStringz;
             args ~= null;
@@ -807,7 +807,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         } else {
             auto sub = tokens[1 .. $].join(" ");
             auto rc = system(sub);
-            import core.stdc.stdlib : exit;
+            import kernel.lib.stdc.stdlib : exit;
             exit(rc);
         }
     } else if(op == "exit") {
@@ -819,12 +819,12 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
                 // ignore invalid argument
             }
         }
-        import core.stdc.stdlib : exit;
+        import kernel.lib.stdc.stdlib : exit;
         exit(code);
     } else if(op == "expand") {
         expand.expandCommand(tokens);
     } else if(op == "false") {
-        import core.stdc.stdlib : exit;
+        import kernel.lib.stdc.stdlib : exit;
         exit(1);
     } else if(op == "expr") {
         exprCommand(tokens);

--- a/kernel/kernel/utils/ansi_art.d
+++ b/kernel/kernel/utils/ansi_art.d
@@ -1,0 +1,6 @@
+module kernel.utils.ansi_art;
+immutable string ANSI_ART = q"EOF"
+ESC[1;31mHello from ANSI Art!ESC[0m
+ESC[1;34mBlue TextESC[0m
+ESC[HESC[2JThis will clear screen and go to top.
+EOF";

--- a/scripts/generate_ansi_art.sh
+++ b/scripts/generate_ansi_art.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Simple script to convert ANSI art to a D string constant
+input="$1"
+[ -z "$input" ] && exit 1
+cat <<'EOM'
+module kernel.utils.ansi_art;
+immutable string ANSI_ART = q"EOF"
+EOM
+cat "$input"
+cat <<'EOM'
+EOF";
+EOM


### PR DESCRIPTION
## Summary
- add stub for exit in kernel's stdlib and import required process functions
- update shell to use kernel stdlib for exit calls
- include userspace stubs in compiler flags
- provide script for generating ANSI art module and regenerate the file

## Testing
- `make build` *(fails: module `mstd.file` import `mkdir` not found, and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887f750c02483279e480e9e59b00733