### PR TITLE
fix page table loop

### DIFF
--- a/kernel/arch/x86/boot/boot.s
+++ b/kernel/arch/x86/boot/boot.s
@@ -149,7 +149,7 @@ setup_page_tables:
     movl $0, 4(%edi)
     addl $0x200000, %eax
     addl $8, %edi
-    incl %ecx
+    addl $1, %ecx
     cmpl $512, %ecx
     jne 1b
 


### PR DESCRIPTION
## Summary
- patch `setup_page_tables` to use `addl $1, %ecx`

## Testing
- `make build` *(fails: module `mstd.file` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a4bb8db2c8327b63b2602393b4aaf