### PR TITLE
Fix kernel paging to cover 4MiB

### DIFF
--- a/kernel/arch/x86/boot/boot.s
+++ b/kernel/arch/x86/boot/boot.s
@@ -79,12 +79,17 @@ _start:
     # Long mode jump
     ljmp $0x08, $long_mode_start
 
-# setup_page_tables - simplified, maps 0–2MiB
+# setup_page_tables - simplified, maps 0–4MiB
 setup_page_tables:
     movl $pd_table, %edi
     movl $0x00000083, %eax     # 2MiB page
     movl %eax, (%edi)
     movl $0, 4(%edi)
+
+    # map 2–4MiB as well in case the kernel crosses 2MiB boundary
+    movl $0x00200083, %eax     # second 2MiB page
+    movl %eax, 8(%edi)
+    movl $0, 12(%edi)
 
     movl $pd_table, %eax
     orl $0x3, %eax


### PR DESCRIPTION
## Summary
- map a second 2MiB page during early boot

## Testing
- `make run-boot-only` *(fails: undefined symbol `kmain`)*
- `make build` *(fails: fs_embedded.d error)*

------
https://chatgpt.com/codex/tasks/task_e_688b9354f2748327a03739b3e6f3a904