### PR TITLE
Fix long_mode_start stall by mapping 6MiB

### DIFF
--- a/kernel/arch/x86/boot/boot.s
+++ b/kernel/arch/x86/boot/boot.s
@@ -79,7 +79,7 @@ _start:
     # Long mode jump
     ljmp $0x08, $long_mode_start
 
-# setup_page_tables - simplified, maps 0–4MiB
+# setup_page_tables - simplified, maps 0–6MiB
 setup_page_tables:
     movl $pd_table, %edi
     movl $0x00000083, %eax     # 2MiB page
@@ -90,6 +90,11 @@ setup_page_tables:
     movl $0x00200083, %eax     # second 2MiB page
     movl %eax, 8(%edi)
     movl $0, 12(%edi)
+
+    # map 4–6MiB to cover larger kernels
+    movl $0x00400083, %eax     # third 2MiB page
+    movl %eax, 16(%edi)
+    movl $0, 20(%edi)
 
     movl $pd_table, %eax
     orl $0x3, %eax


### PR DESCRIPTION
## Summary
- extend early page table setup to map three 2MiB pages
- this covers kernels larger than 4MiB so the BSS clear loop no longer traps

## Testing
- `as --64 kernel/arch/x86/boot/boot.s -o build/boot.o`
- `ld.lld -nostdlib -no-pie -T kernel/arch/x86/linker.ld -o build/boot-only.bin build/boot.o build/dummy_kmain.o` *(fails: dummy_kmain file removed)*

------
https://chatgpt.com/codex/tasks/task_e_688b951efc4c832796204d59aacfe140