### PR TITLE
Fix boot to use -sh shell

### DIFF
--- a/kernel/kernel/core/main.d
+++ b/kernel/kernel/core/main.d
@@ -186,7 +186,7 @@ extern (C) void kmain(void* multiboot_info_ptr) {
         import kernel.elf_loader : load_elf;
         import kernel.process_manager : EntryFunc;
         void* entry;
-        if(load_elf("/bin/hello", &entry) == 0 && entry !is null)
+        if(load_elf("/bin/sh", &entry) == 0 && entry !is null)
         {
             (cast(EntryFunc)entry)();
         }


### PR DESCRIPTION
## Summary
- load `/bin/sh` by default rather than the `/bin/hello` test binary

## Testing
- `make -n | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688bab2fb6bc8327ac888579408edc60